### PR TITLE
fix function pass in addEventListener

### DIFF
--- a/src/Element.js
+++ b/src/Element.js
@@ -113,8 +113,10 @@ Element.prototype.eventToPropName = function (name) {
   return this.eventNameMappings[name] || name
 }
 
-Element.prototype.addEventListener = function (name, fn) {
-  this.props[this.eventToPropName(name)] = fn
+Element.prototype.addEventListener = function (name, fn, d) {
+  this.props[this.eventToPropName(name)] = function (e) {
+    fn(e, d)
+  }
 }
 
 Element.prototype.removeEventListener = function (name, fn) {


### PR DESCRIPTION
fix function pass in addEventListener, so it is possible to pass extra parameters while event trigger in d3 events.

I don't know whether it is the best solution. But this help me to achieve passing events and parameters in d3 DOM.

For example:

https://github.com/react-d3/react-d3-tooltip/blob/feature/react-faux-dom/src/utils/voronoi.jsx#L73-L92

```js
 voronoiPath.each(function(p) {
      var evtObj = {
        data: p,
        xScaleSet: xScaleSet,
        yScaleSet: yScaleSet,
        focus: focus,
        stack: stack
      }

      this.addEventListener('mouseover', (e, d) => {
        return focus?
          onMouseOver(e, d.data, d.xScaleSet, d.yScaleSet, d.focus, d.stack):
          onMouseOver(e, d.data, d.xScaleSet, d.yScaleSet)
        }, evtObj)
      this.addEventListener('mouseout', (e, d) => {
        return focus?
          onMouseOut(e, d.data, d.xScaleSet, d.yScaleSet, d.focus, d.stack):
          onMouseOut(e, d.data, d.xScaleSet, d.yScaleSet)
        }, evtObj)
    })
```

By the way, I'm moving my whole react-d3 (http://reactd3.org) library using `react-faux-dom` ! Thank you so much for building this library!

P.S. 
I've see you mention about `d3.mouse` or `d3.event` 

https://github.com/Olical/react-faux-dom/issues/9

In this solution many event properties can be access in `SyntheticEvent` object, like clientX, clientY... 
