### PR TITLE
support customized attibutes and aria-* attributes

### DIFF
--- a/src/Element.js
+++ b/src/Element.js
@@ -88,7 +88,13 @@ Element.prototype.attributeNameMappings = {
 }
 
 Element.prototype.attributeToPropName = function (name) {
-  return this.attributeNameMappings[name] || camelCase(name)
+  if (name.match(/^data-/)) {
+    return name
+  } else if (name.match(/^aria-/)) {
+    return name
+  } else {
+    return this.attributeNameMappings[name] || camelCase(name)
+  }
 }
 
 Element.prototype.setAttribute = function (name, value) {

--- a/test/react.js
+++ b/test/react.js
@@ -54,6 +54,34 @@ test('pre-built React elements are rendered into the tree', function (t) {
   t.equal(tree.props.children[0].props.foo, 'bar')
 })
 
+test('React elements customize data-* attributes are rendered into the tree', function (t) {
+  var el = mk().node()
+  var sub = mk()
+    .attr('data-foo', 'bar')
+    .node()
+    .toReact()
+
+  el.appendChild(sub)
+  var tree = el.toReact()
+
+  t.plan(1)
+  t.equal(tree.props.children[0].props['data-foo'], 'bar')
+})
+
+test('React elements aria-* attributes are rendered into the tree', function (t) {
+  var el = mk().node()
+  var sub = mk()
+    .attr('aria-hidden', 'true')
+    .node()
+    .toReact()
+
+  el.appendChild(sub)
+  var tree = el.toReact()
+
+  t.plan(1)
+  t.equal(tree.props.children[0].props['aria-hidden'], 'true')
+})
+
 test('toReact does not mutate the state', function (t) {
   var el = mk().node()
   t.plan(2)


### PR DESCRIPTION
https://facebook.github.io/react/docs/jsx-gotchas.html#custom-html-attributes

Customized attributes like `data-custom-attributes` are converted into camel case, it should not be converted. So does `aria-*` attributes.