### PR TITLE
Define childNodes in `Element`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lodash.assign": "^3.2.0",
     "lodash.camelcase": "^3.0.1",
     "lodash.clone": "^3.0.3",
+    "lodash.filter": "^3.1.1",
     "lodash.mapvalues": "^3.0.1",
     "lodash.some": "^3.2.3",
     "query-selector": "^1.0.9",

--- a/src/Element.js
+++ b/src/Element.js
@@ -4,6 +4,7 @@ var styleAttr = require('style-attr')
 var camelCase = require('lodash.camelcase')
 var assign = require('lodash.assign')
 var some = require('lodash.some')
+var filter = require('lodash.filter')
 var mapValues = require('lodash.mapvalues')
 var querySelectorAll = require('query-selector')
 
@@ -20,7 +21,7 @@ function styleCamelCase (name) {
 function Element (nodeName, parentNode) {
   this.nodeName = nodeName
   this.parentNode = parentNode
-  this.children = []
+  this.childNodes = []
   this.eventListeners = {}
   this.text = ''
   var props = this.props = {
@@ -160,26 +161,26 @@ Element.prototype.removeEventListener = function (name, fn) {
 
 Element.prototype.appendChild = function (el) {
   el.parentNode = this
-  this.children.push(el)
+  this.childNodes.push(el)
   return el
 }
 
 Element.prototype.insertBefore = function (el, before) {
-  var index = this.children.indexOf(before)
+  var index = this.childNodes.indexOf(before)
   el.parentNode = this
 
   if (index !== -1) {
-    this.children.splice(index, 0, el)
+    this.childNodes.splice(index, 0, el)
   } else {
-    this.children.push(el)
+    this.childNodes.push(el)
   }
 
   return el
 }
 
 Element.prototype.removeChild = function (child) {
-  var target = this.children.indexOf(child)
-  this.children.splice(target, 1)
+  var target = this.childNodes.indexOf(child)
+  this.childNodes.splice(target, 1)
 }
 
 Element.prototype.querySelector = function () {
@@ -310,6 +311,21 @@ Object.defineProperties(Element.prototype, {
     },
     set: function (text) {
       this.text = text
+    }
+  },
+  children: {
+    get: function () {
+      // So far nodes created by this library are all of nodeType 1 (elements),
+      // but this could change in the future.
+      return filter(this.childNodes, function (el) {
+        if (!el.nodeType) {
+          // It's a React element, we always add it
+          return true
+        }
+
+        // It's a HTML node. We want to filter to have only nodes with type 1
+        return el.nodeType === 1
+      })
     }
   }
 })

--- a/test/essentials.js
+++ b/test/essentials.js
@@ -1,5 +1,6 @@
 var test = require('tape')
 var ReactFauxDOM = require('..')
+var Element = require('../src/Element')
 
 test('has a create method', function (t) {
   t.plan(1)
@@ -20,4 +21,24 @@ test('hyphenated properties are camel cased', function (t) {
   t.equal(el.getAttribute('text-align'), 'right')
   t.equal(el.getAttribute('textAlign'), 'right')
   t.equal(el.toReact().props.textAlign, 'right')
+})
+
+test('children and childNodes behave properly', function (t) {
+  var parentEl = ReactFauxDOM.createElement('div')
+  var el = ReactFauxDOM.createElement('div')
+  var elReact = ReactFauxDOM.createElement('div').toReact()
+  var textNode = ReactFauxDOM.createElement('TextElement')
+  textNode.nodeType = 3
+
+  parentEl.appendChild(el)
+  parentEl.appendChild(elReact)
+  parentEl.appendChild(textNode)
+
+  t.plan(5)
+  t.equal(parentEl.childNodes.length, 3)
+  t.equal(parentEl.children.length, 2)
+
+  t.ok(parentEl.childNodes[0] instanceof Element)
+  t.equal(parentEl.childNodes[1].type, el.nodeName)
+  t.equal(parentEl.childNodes[2].nodeType, 3)
 })


### PR DESCRIPTION
Right now, by only having `children`, any library that uses `childNodes` to get the element children will fail. `childNodes` is used to get nodes of all types (not only 1, like `.children` does). Children is implemented as a filter on `.childNodes` for nodes of type === 1.

An example of d3 code that will currently fail:
```javascript
svg.append('g')
  .select('.tick:last-of-type');
```
It fails because the library `query-selector` uses `childNodes` internally (https://github.com/yiminghe/query-selector/blob/master/build/query-selector-debug.js#L2700).

