### PR TITLE
Fix vendor prefixes for already camelCased style names

### DIFF
--- a/src/Element.js
+++ b/src/Element.js
@@ -11,6 +11,12 @@ var querySelectorAll = require('query-selector')
 function styleCamelCase (name) {
   var camel = camelCase(name)
 
+  // Detect if the style property is already camelCased
+  // To not convert Webkit*, Moz* and O* to lowercase
+  if (camel.slice(1) === name.slice(1)) {
+    return name
+  }
+
   if (name[0] === '-') {
     return camel[0].toUpperCase() + camel.slice(1)
   } else {

--- a/src/Element.js
+++ b/src/Element.js
@@ -18,7 +18,8 @@ function styleCamelCase (name) {
   }
 
   if (name[0] === '-') {
-    return camel[0].toUpperCase() + camel.slice(1)
+    return camel.indexOf('ms') === 0 ? camel
+      : camel[0].toUpperCase() + camel.slice(1)
   } else {
     return camel
   }

--- a/src/Element.js
+++ b/src/Element.js
@@ -13,13 +13,13 @@ function styleCamelCase (name) {
 
   // Detect if the style property is already camelCased
   // To not convert Webkit*, Moz* and O* to lowercase
-  if (camel.slice(1) === name.slice(1)) {
-    return name
+  if (camel.charAt(0).toUpperCase() === name.charAt(0)) {
+    return name.charAt(0) + camel.slice(1)
   }
 
-  if (name[0] === '-') {
+  if (name.charAt(0) === '-') {
     return camel.indexOf('ms') === 0 ? camel
-      : camel[0].toUpperCase() + camel.slice(1)
+      : camel.charAt(0).toUpperCase() + camel.slice(1)
   } else {
     return camel
   }

--- a/test/style.js
+++ b/test/style.js
@@ -53,3 +53,10 @@ test('vendor prefixed styles are correctly camel-cased', function (t) {
   t.plan(1)
   t.equal(el.style.WebkitTransition, 'opacity 100ms ease')
 })
+
+test('pascal-cased, vendor prefixed styles are not camel-cased', function (t) {
+  var el = mk().node()
+  el.setAttribute('style', 'WebkitTransition: opacity 100ms ease')
+  t.plan(1)
+  t.equal(el.style.WebkitTransition, 'opacity 100ms ease')
+})

--- a/test/style.js
+++ b/test/style.js
@@ -60,3 +60,11 @@ test('pascal-cased, vendor prefixed styles are not camel-cased', function (t) {
   t.plan(1)
   t.equal(el.style.WebkitTransition, 'opacity 100ms ease')
 })
+
+test('-ms- and ms* vendor prefixed styles are supported', function (t) {
+  t.plan(2)
+  var el = mk().node()
+  el.setAttribute('style', 'msTransform: opacity 100ms ease; -ms-animation: 1s ease popIn')
+  t.equal(el.style.msTransform, 'opacity 100ms ease')
+  t.equal(el.style.msAnimation, '1s ease popIn')
+})


### PR DESCRIPTION
I am using `react-faux-dom` for a project where certain components are rendered with d3 and love it :smile:

I'm also writing all of the `.style` objects with React's usual camelCased style names. This is just for convenience and I'm also reusing some helpers that generate camelCased style names as well.

I noticed that vendor-prefixed / PascalCased style names are unfortunately camelCased again. Thus these style names are not correctly picked by React afterwards, as `react-faux-dom` is converting them again. This just adds a small check to see whether the `styleName.slice(1)` is already camelCased and returns the original if it is.

So nothing changes except that `WebkitTransform` is not converted to `webkitTransform`.

Cheers!