### PR TITLE
Add pre-building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dist/

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,17 @@
-.PHONY: default bootstrap test test-watch
+.PHONY: default bootstrap test test-watch build
+
+bin = ./node_modules/.bin
 
 default: bootstrap test
 
 bootstrap:
-	@npm install
+	npm install
 
 test:
-	@npm test
+	npm test
 
 test-watch:
-	@./node_modules/.bin/nodemon --exec "npm test"
+	./node_modules/.bin/nodemon --exec "npm test"
+
+build:
+	$(bin)/bastion -e ./lib/ReactFauxDOM.js -b ./dist/ReactFauxDOM.min.js

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ I'm trying to keep it light so as not to slow down your render function. I want 
 
 You can install the package `react-faux-dom` from npm as you usually would. Then use webpack or browserify (etc) to bundle the source into your build. If you need a pre-built UMD version you can use [npmcdn][].
 
-For example, https://npmcdn.com/react-faux-dom@2.5.0/dist/ReactFauxDOM.min.js fetches `v2.5.0` and https://npmcdn.com/react-faux-dom/dist/ReactFauxDOM.min.js fetches the latest version.
+ * You can fetch a version - https://npmcdn.com/react-faux-dom@2.5.0/dist/ReactFauxDOM.min.js
+ * Or a specific version - https://npmcdn.com/react-faux-dom/dist/ReactFauxDOM.min.js
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -31,14 +31,17 @@ this.animateFauxDOM(3500); // duration + margin
 return {this.state.chart};
 ```
 
-
 ReactFauxDOM supports a wide range of DOM operations and will fool most libraries but it isn't exhaustive (the full DOM API is ludicrously large). It supports enough to work with D3 but will require you to fork and add to the project if you encounter something that's missing.
 
 You can think of this as a bare bones [jsdom][] that's built to bridge the gap between the declarative React and the imperative JavaScript world. We just need to expand it as we go along since jsdom is a huge project that solves different problems.
 
 I'm trying to keep it light so as not to slow down your render function. I want efficient, declarative and stateless code, but I don't want to throw away previous tools to get there.
 
+## Installation
 
+You can install the package `react-faux-dom` from npm as you usually would. Then use webpack or browserify (etc) to bundle the source into your build. If you need a pre-built UMD version you can use [npmcdn][].
+
+For example, https://npmcdn.com/react-faux-dom@2.5.0/dist/ReactFauxDOM.min.js fetches `v2.5.0` and https://npmcdn.com/react-faux-dom/dist/ReactFauxDOM.min.js fetches the latest version.
 
 ## Usage
 
@@ -92,3 +95,4 @@ Do what you want. Learn as much as you can. Unlicense more software.
 [react-motion]: https://github.com/chenglou/react-motion
 [mixin-example]: ./examples/animate-d3-with-mixin
 [component-kit]: https://github.com/kennetpostigo/component-kit
+[npmcdn]: https://npmcdn.com/

--- a/bastion.conf.js
+++ b/bastion.conf.js
@@ -1,0 +1,14 @@
+export function webpack (config) {
+  config.output.library = 'react-faux-dom'
+  config.output.libraryTarget = 'umd'
+  config.externals = [
+    {
+      react: {
+        root: 'React',
+        commonjs2: 'react',
+        commonjs: 'react',
+        amd: 'react'
+      }
+    }
+  ]
+}

--- a/examples/animate-d3-with-mixin/index.js
+++ b/examples/animate-d3-with-mixin/index.js
@@ -153,4 +153,4 @@ var Chart = React.createClass({
   }
 })
 
-ReactDOM.render(<Chart/>, document.getElementById('container'))
+ReactDOM.render(<Chart />, document.getElementById('container'))

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "homepage": "https://github.com/Olical/react-faux-dom#readme",
   "devDependencies": {
-    "babel-eslint": "^6.0.5",
     "bastion": "^1.7.0",
     "d3": "^3.5.16",
     "faucet": "0.0.1",
@@ -39,7 +38,6 @@
     "react": "^15.1.0",
     "sinon": "^1.17.3",
     "standard": "^7.1.2",
-    "standard-loader": "^4.0.0",
     "tape": "^4.4.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/Olical/react-faux-dom#readme",
   "devDependencies": {
-    "bastion": "^1.7.0",
+    "bastion": "^1.8.0",
     "d3": "^3.5.16",
     "faucet": "0.0.1",
     "nodemon": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,12 @@
   "description": "DOM like data structure to be mutated by D3 et al, then rendered to React elements",
   "main": "lib/ReactFauxDOM.js",
   "scripts": {
-    "test": "standard && tape './test/**/*.js' | faucet"
+    "test": "standard && tape './test/**/*.js' | faucet",
+    "prepublish": "npm test && make build"
   },
+  "files": [
+    "./dist/ReactFauxDOM.min.js"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Olical/react-faux-dom.git"
@@ -27,12 +31,15 @@
   },
   "homepage": "https://github.com/Olical/react-faux-dom#readme",
   "devDependencies": {
+    "babel-eslint": "^6.0.5",
+    "bastion": "^1.7.0",
     "d3": "^3.5.16",
     "faucet": "0.0.1",
     "nodemon": "^1.9.1",
-    "react": "^0.14.7",
+    "react": "^15.1.0",
     "sinon": "^1.17.3",
-    "standard": "^6.0.7",
+    "standard": "^7.1.2",
+    "standard-loader": "^4.0.0",
     "tape": "^4.4.0"
   },
   "dependencies": {


### PR DESCRIPTION
Another approach to #48. Uses my https://github.com/Olical/bastion project for simplicity but that could do with some work I guess. Needed two extra dependencies that shouldn't have been required.

So this should publish to npmcdn when I release the npm module. Could you verify that the built file works for you? Try downloading, `npm installing` and running `make build`. Then use `./dist/ReactFauxDOM.min.js` in an existing example.