### PR TITLE
Tests passing for d3 v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "homepage": "https://github.com/Olical/react-faux-dom#readme",
   "devDependencies": {
     "bastion": "^1.8.0",
-    "d3": "^3.5.16",
+    "d3": "^4.1.1",
+    "d3-selection-multi": "^0.4.1",
     "faucet": "0.0.1",
     "nodemon": "^1.9.1",
     "react": "^15.1.0",

--- a/test/d3.js
+++ b/test/d3.js
@@ -77,7 +77,7 @@ test('removing a child', function (t) {
 
 test('styles', function (t) {
   var el = mk()
-    .style({
+    .styles({
       'stroke-width': '2px',
       opacity: 0.5
     })

--- a/test/test-utils/mk.js
+++ b/test/test-utils/mk.js
@@ -1,5 +1,6 @@
 var ReactFauxDOM = require('../..')
 var d3 = require('d3')
+require('d3-selection-multi')
 
 function mk () {
   var sel = d3.select(ReactFauxDOM.createElement('div'))


### PR DESCRIPTION
Fixing #54.

- [x] All tests passing.
- [x] The example shows an animated bar chart and there are no errors in the console.

Attempted to give a birds-eye view of [what was broken here](https://github.com/Olical/react-faux-dom/issues/54#issuecomment-232314092).

Ultimately most of the changes to the API do not affect this package as they are passed onto the user; the fixes were to the tests. Engineers will need to rewrite their React components to use the new v4 d3 APIs.