### PR TITLE
Fix automatic keys and Elements with a single child

### DIFF
--- a/lib/Element.js
+++ b/lib/Element.js
@@ -245,20 +245,15 @@ Element.prototype.getBoundingClientRect = function () {
   return this.component.getBoundingClientRect()
 }
 
-Element.prototype.toReact = function (index) {
+Element.prototype.toReact = function (idPrefix, index) {
+  idPrefix = idPrefix || 'faux-dom'
   index = index || 0
+
   var props = assign({}, this.props)
   props.style = assign({}, props.style)
+  props.key = isUndefined(props.key) ? idPrefix + '-' + index : props.key
 
   var originalElement = this
-
-  function uniqueKey () {
-    return 'faux-dom-' + index
-  }
-
-  if (isUndefined(props.key)) {
-    props.key = uniqueKey()
-  }
 
   delete props.style.setProperty
   delete props.style.getProperty
@@ -281,7 +276,7 @@ Element.prototype.toReact = function (index) {
 
   return React.createElement(this.nodeName, props, this.text || this.children.map(function (el, i) {
     if (el instanceof Element) {
-      return el.toReact(i)
+      return el.toReact(props.key, i)
     } else {
       return el
     }

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -7,6 +7,7 @@ var isUndefined = require('./utils/isUndefined')
 var assign = require('./utils/assign')
 var mapValues = require('./utils/mapValues')
 var styleCamelCase = require('./utils/styleCamelCase')
+var uniqueID = require('./utils/uniqueID')
 
 function Element (nodeName, parentNode) {
   this.nodeName = nodeName
@@ -245,13 +246,13 @@ Element.prototype.getBoundingClientRect = function () {
   return this.component.getBoundingClientRect()
 }
 
-Element.prototype.toReact = function (idPrefix, index) {
-  idPrefix = idPrefix || 'faux-dom'
-  index = index || 0
-
+Element.prototype.toReact = function (id) {
   var props = assign({}, this.props)
   props.style = assign({}, props.style)
-  props.key = isUndefined(props.key) ? idPrefix + '-' + index : props.key
+
+  if (isUndefined(props.key) && id) {
+    props.key = id
+  }
 
   var originalElement = this
 
@@ -274,16 +275,39 @@ Element.prototype.toReact = function (idPrefix, index) {
     }
   }))
 
-  return React.createElement(this.nodeName, props, this.text || this.children.map(function (el, i) {
-    if (el instanceof Element) {
-      return el.toReact(props.key, i)
-    } else {
+  var children
+
+  if (this.text) {
+    children = this.text
+  } else if (this.children.length === 1) {
+    var el = this.children[0]
+    children = el instanceof Element ? el.toReact() : el
+  } else if (this.children.length > 1) {
+    children = this.children.map(function (el) {
+      if (el instanceof Element) {
+        return el.toReact(el.key)
+      }
+
       return el
-    }
-  }))
+    })
+  }
+
+  return React.createElement(this.nodeName, props, children)
 }
 
 Object.defineProperties(Element.prototype, {
+  key: {
+    get: function () {
+      if (!this._key) {
+        this._key = uniqueID()
+      }
+
+      return this._key
+    },
+    set: function (id) {
+      this._key = id
+    }
+  },
   nextSibling: {
     get: function () {
       var siblings = this.parentNode.children

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -15,6 +15,8 @@ function Element (nodeName, parentNode) {
   this.childNodes = []
   this.eventListeners = {}
   this.text = ''
+  this.key = uniqueID()
+
   var self = this
   var props = this.props = {
     ref: function (component) {
@@ -296,18 +298,6 @@ Element.prototype.toReact = function (id) {
 }
 
 Object.defineProperties(Element.prototype, {
-  key: {
-    get: function () {
-      if (!this._key) {
-        this._key = uniqueID()
-      }
-
-      return this._key
-    },
-    set: function (id) {
-      this._key = id
-    }
-  },
   nextSibling: {
     get: function () {
       var siblings = this.parentNode.children

--- a/lib/mixins/core.js
+++ b/lib/mixins/core.js
@@ -1,12 +1,10 @@
 var Element = require('../Element')
 var mapValues = require('../utils/mapValues')
-var uniqueID = require('../utils/uniqueID')
 
 var mixin = {
   componentWillMount: function () {
     this.connectedFauxDOM = {}
     this.animateFauxDOMUntil = 0
-    this.fauxID = 'faux-mixin-' + uniqueID()
   },
   connectFauxDOM: function (node, name) {
     this.connectedFauxDOM[name] = typeof node !== 'string' ? node : new Element(node)
@@ -15,7 +13,7 @@ var mixin = {
   },
   drawFauxDOM: function () {
     var virtualDOM = mapValues(this.connectedFauxDOM, function (n) {
-      return n.toReact(this.fauxID)
+      return n.toReact()
     })
     this.setState(virtualDOM)
   }

--- a/lib/mixins/core.js
+++ b/lib/mixins/core.js
@@ -1,10 +1,12 @@
 var Element = require('../Element')
 var mapValues = require('../utils/mapValues')
+var uniqueID = require('../utils/uniqueID')
 
 var mixin = {
   componentWillMount: function () {
     this.connectedFauxDOM = {}
     this.animateFauxDOMUntil = 0
+    this.fauxID = 'faux-mixin-' + uniqueID()
   },
   connectFauxDOM: function (node, name) {
     this.connectedFauxDOM[name] = typeof node !== 'string' ? node : new Element(node)
@@ -13,7 +15,7 @@ var mixin = {
   },
   drawFauxDOM: function () {
     var virtualDOM = mapValues(this.connectedFauxDOM, function (n) {
-      return n.toReact()
+      return n.toReact(this.fauxID)
     })
     this.setState(virtualDOM)
   }

--- a/lib/utils/uniqueID.js
+++ b/lib/utils/uniqueID.js
@@ -1,0 +1,7 @@
+var index = 0
+
+function uniqueID () {
+  return index++
+}
+
+module.exports = uniqueID

--- a/lib/utils/uniqueID.js
+++ b/lib/utils/uniqueID.js
@@ -1,7 +1,9 @@
 var index = 0
 
+// This is of course not using UUIDs, but should be totally sufficient
+// for our use case
 function uniqueID () {
-  return index++
+  return 'faux-dom-' + (index++)
 }
 
 module.exports = uniqueID

--- a/test/react.js
+++ b/test/react.js
@@ -35,14 +35,14 @@ test('auto default keys', function (t) {
   // 2
   el.append('p').attr('foo', 'bar')
 
-  var tree = el.node().toReact()
+  var tree = el.node().toReact('test')
 
   t.plan(6)
-  t.equal(tree.key, 'faux-dom-0')
-  t.equal(tree.props.children[0].key, 'faux-dom-0-0')
+  t.equal(tree.key, 'test')
+  t.notEqual(tree.props.children[0].key, undefined)
   t.equal(tree.props.children[1].key, 'testing')
-  t.equal(tree.props.children[1].props.children[0].key, 'testing-0')
-  t.equal(tree.props.children[2].key, 'faux-dom-0-2')
+  t.equal(tree.props.children[1].props.children._key, undefined)
+  t.notEqual(tree.props.children[2].key, undefined)
   t.equal(tree.props.children[2].props.foo, 'bar')
 })
 
@@ -57,7 +57,7 @@ test('pre-built React elements are rendered into the tree', function (t) {
   var tree = el.toReact()
 
   t.plan(1)
-  t.equal(tree.props.children[0].props.foo, 'bar')
+  t.equal(tree.props.children.props.foo, 'bar')
 })
 
 test('React elements customize data-* attributes are rendered into the tree', function (t) {
@@ -71,7 +71,7 @@ test('React elements customize data-* attributes are rendered into the tree', fu
   var tree = el.toReact()
 
   t.plan(1)
-  t.equal(tree.props.children[0].props['data-foo'], 'bar')
+  t.equal(tree.props.children.props['data-foo'], 'bar')
 })
 
 test('React elements aria-* attributes are rendered into the tree', function (t) {
@@ -85,7 +85,7 @@ test('React elements aria-* attributes are rendered into the tree', function (t)
   var tree = el.toReact()
 
   t.plan(1)
-  t.equal(tree.props.children[0].props['aria-hidden'], 'true')
+  t.equal(tree.props.children.props['aria-hidden'], 'true')
 })
 
 test('toReact does not mutate the state', function (t) {

--- a/test/react.js
+++ b/test/react.js
@@ -26,17 +26,23 @@ test('nested text', function (t) {
 
 test('auto default keys', function (t) {
   var el = mk()
+  // 0
   el.append('p')
-  el.append('p').attr('key', 'testing')
+  // 1
+  var sub = el.append('p').attr('key', 'testing')
+  // 1.0
+  sub.append('p')
+  // 2
   el.append('p').attr('foo', 'bar')
 
   var tree = el.node().toReact()
 
-  t.plan(5)
+  t.plan(6)
   t.equal(tree.key, 'faux-dom-0')
-  t.equal(tree.props.children[0].key, 'faux-dom-0')
+  t.equal(tree.props.children[0].key, 'faux-dom-0-0')
   t.equal(tree.props.children[1].key, 'testing')
-  t.equal(tree.props.children[2].key, 'faux-dom-2')
+  t.equal(tree.props.children[1].props.children[0].key, 'testing-0')
+  t.equal(tree.props.children[2].key, 'faux-dom-0-2')
   t.equal(tree.props.children[2].props.foo, 'bar')
 })
 


### PR DESCRIPTION
Fix #67 

Before keys were only unique on a single level.
Thus when a tree with two separate groups of children
were generated, these children could still have the same
keys.

This fix appends the element index to the previous key.

There is a remaining problem: When the user has multiple
faux doms, these doms can still have overlapping ids.

This can be circumvented however, by the user
passing his custom key prefix:

``` js
elA.toReact('first-dom')
elB.toReact('second-dom')
```
