### PR TITLE
Remove automatic keys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,14 @@
 # react-faux-dom changes
 
+## v4.0.0
+
+ * More neat README examples!
+ * Remove default React key allocation and document it. See [#67](https://github.com/Olical/react-faux-dom/issues/67), [#73](https://github.com/Olical/react-faux-dom/pull/73) and [#74](https://github.com/Olical/react-faux-dom/pull/74).
+
 ## v3.0.0
 
  * Merge [#69](https://github.com/Olical/react-faux-dom/pull/69) - Return an empty string from style getters by default. From issue [#68](https://github.com/Olical/react-faux-dom/issues/68).
  * Merge [#71](https://github.com/Olical/react-faux-dom/pull/71) - Changes npmcdn URLs to unpkg. Not sure why they're doing this but oh well.
- *
 
 Breaking change because of the following:
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -29,7 +29,7 @@ As you can see, you can embed React components into the faux DOM seamlessly. Mut
 
 Just like normal React, if you have multiple children you should assign a unique `key` to them so React knows what's what as it moves and changes. You can do that with `.setAttribute('key', 'foo')` or if you're using D3 `.attr('key', 'foo')`. React will log an error if you forget to do this anywhere.
 
-> Previously, `v3.0.0` and below, ReactFauxDOM would automatically generate keys to suppress most of these errors and make it easier on the user, but this can lead to subtle performance problems that may be hard to find. This can be significant issues if you have lot of elements, say, points on a large graph.
+> Previously, `v3.0.0` and below, ReactFauxDOM would automatically generate keys to suppress most of these errors and make it easier on the user, but this can lead to subtle performance problems that may be hard to find. This can lead to significant issues if you have lot of elements, say, points on a large graph.
 
 ### Manipulating
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -27,6 +27,10 @@ paragraph.appendChild(someReactElement)
 
 As you can see, you can embed React components into the faux DOM seamlessly. Mutating those children obviously won't work, but it allows you to optimise your rendering significantly.
 
+Just like normal React, if you have multiple children you should assign a unique `key` to them so React knows what's what as it moves and changes. You can do that with `.setAttribute('key', 'foo')` or if you're using D3 `.attr('key', 'foo')`. React will log an error if you forget to do this anywhere.
+
+> Previously, `v3.0.0` and below, ReactFauxDOM would automatically generate keys to suppress most of these errors and make it easier on the user, but this can lead to subtle performance problems that may be hard to find. This can be significant issues if you have lot of elements, say, points on a large graph.
+
 ### Manipulating
 
 You can pass these elements to things like D3 and then use that library as you normally would. All they do is call the underlying DOM manipulation methods I have implemented so far like this.

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -245,8 +245,7 @@ Element.prototype.getBoundingClientRect = function () {
   return this.component.getBoundingClientRect()
 }
 
-Element.prototype.toReact = function (index) {
-  index = index || 0
+Element.prototype.toReact = function () {
   var props = assign({}, this.props)
   props.style = assign({}, props.style)
 
@@ -280,7 +279,7 @@ function getChild (node) {
   } else {
     var children = node.children.map(function (el, i) {
       if (el instanceof Element) {
-        return el.toReact(i)
+        return el.toReact()
       } else {
         return el
       }

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -271,13 +271,23 @@ Element.prototype.toReact = function (index) {
     }
   }))
 
-  return React.createElement(this.nodeName, props, this.text || this.children.map(function (el, i) {
-    if (el instanceof Element) {
-      return el.toReact(i)
-    } else {
-      return el
-    }
-  }))
+  return React.createElement(this.nodeName, props, getChild(this))
+}
+
+function getChild (node) {
+  if (node.text) {
+    return node.text
+  } else {
+    var children = node.children.map(function (el, i) {
+      if (el instanceof Element) {
+        return el.toReact(i)
+      } else {
+        return el
+      }
+    })
+
+    return children.length === 1 ? children[0] : children
+  }
 }
 
 Object.defineProperties(Element.prototype, {

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -252,14 +252,6 @@ Element.prototype.toReact = function (index) {
 
   var originalElement = this
 
-  function uniqueKey () {
-    return 'faux-dom-' + index
-  }
-
-  if (isUndefined(props.key)) {
-    props.key = uniqueKey()
-  }
-
   delete props.style.setProperty
   delete props.style.getProperty
   delete props.style.removeProperty

--- a/test/react.js
+++ b/test/react.js
@@ -11,9 +11,11 @@ test('simple node', function (t) {
 
 test('nested text', function (t) {
   var el = mk()
-  el.append('p').text('one')
-  el.append('p').text('two')
-  el.append('p').text('three')
+  var keys = ['one', 'two', 'three']
+
+  keys.forEach(function (n) {
+    el.append('p').attr('key', n).text(n)
+  })
 
   var tree = el.node().toReact()
 
@@ -24,26 +26,11 @@ test('nested text', function (t) {
   t.equal(tree.props.children[1].props.children, 'two')
 })
 
-test('auto default keys', function (t) {
-  var el = mk()
-  el.append('p')
-  el.append('p').attr('key', 'testing')
-  el.append('p').attr('foo', 'bar')
-
-  var tree = el.node().toReact()
-
-  t.plan(5)
-  t.equal(tree.key, 'faux-dom-0')
-  t.equal(tree.props.children[0].key, 'faux-dom-0')
-  t.equal(tree.props.children[1].key, 'testing')
-  t.equal(tree.props.children[2].key, 'faux-dom-2')
-  t.equal(tree.props.children[2].props.foo, 'bar')
-})
-
 test('pre-built React elements are rendered into the tree', function (t) {
   var el = mk().node()
   var sub = mk()
     .attr('foo', 'bar')
+    .attr('key', 'bar')
     .node()
     .toReact()
 
@@ -58,6 +45,7 @@ test('React elements customize data-* attributes are rendered into the tree', fu
   var el = mk().node()
   var sub = mk()
     .attr('data-foo', 'bar')
+    .attr('key', 'bar')
     .node()
     .toReact()
 
@@ -72,6 +60,7 @@ test('React elements aria-* attributes are rendered into the tree', function (t)
   var el = mk().node()
   var sub = mk()
     .attr('aria-hidden', 'true')
+    .attr('key', 'bar')
     .node()
     .toReact()
 
@@ -107,4 +96,23 @@ test('React elements have a ref attribute', function (t) {
   tree.ref(fakeComponent)
   t.equal(el.component, fakeComponent)
   t.equal(el.getBoundingClientRect(), fakeClientRect)
+})
+
+test('multiple children require keys', function (t) {
+  t.plan(4)
+  var el = mk().node()
+  var children = ['foo', 'bar', 'baz'].map(function (n) {
+    return mk()
+      .text(n)
+      .attr('key', n)
+      .node()
+  })
+
+  children.forEach(el.appendChild.bind(el))
+
+  t.ok(el.toReact())
+
+  t.equal(el.childNodes[0].getAttribute('key'), 'foo')
+  t.equal(el.childNodes[1].getAttribute('key'), 'bar')
+  t.equal(el.childNodes[2].getAttribute('key'), 'baz')
 })

--- a/test/react.js
+++ b/test/react.js
@@ -30,7 +30,6 @@ test('pre-built React elements are rendered into the tree', function (t) {
   var el = mk().node()
   var sub = mk()
     .attr('foo', 'bar')
-    .attr('key', 'bar')
     .node()
     .toReact()
 
@@ -38,14 +37,13 @@ test('pre-built React elements are rendered into the tree', function (t) {
   var tree = el.toReact()
 
   t.plan(1)
-  t.equal(tree.props.children[0].props.foo, 'bar')
+  t.equal(tree.props.children.props.foo, 'bar')
 })
 
 test('React elements customize data-* attributes are rendered into the tree', function (t) {
   var el = mk().node()
   var sub = mk()
     .attr('data-foo', 'bar')
-    .attr('key', 'bar')
     .node()
     .toReact()
 
@@ -53,14 +51,13 @@ test('React elements customize data-* attributes are rendered into the tree', fu
   var tree = el.toReact()
 
   t.plan(1)
-  t.equal(tree.props.children[0].props['data-foo'], 'bar')
+  t.equal(tree.props.children.props['data-foo'], 'bar')
 })
 
 test('React elements aria-* attributes are rendered into the tree', function (t) {
   var el = mk().node()
   var sub = mk()
     .attr('aria-hidden', 'true')
-    .attr('key', 'bar')
     .node()
     .toReact()
 
@@ -68,7 +65,7 @@ test('React elements aria-* attributes are rendered into the tree', function (t)
   var tree = el.toReact()
 
   t.plan(1)
-  t.equal(tree.props.children[0].props['aria-hidden'], 'true')
+  t.equal(tree.props.children.props['aria-hidden'], 'true')
 })
 
 test('toReact does not mutate the state', function (t) {


### PR DESCRIPTION
My ideal scenario, an alternate approach to #67 and #73. May not be to everyone's taste.

Also, the scenario where you need to add a key even with just one child can probably be avoided some other way. I will have a think about that one. I just wanted to show that it's pretty easy to just add keys where React tells you to.

Should yield more efficient applications too, right now I would imagine many people using this are seeing far higher CPU usage because they don't understand the key system. Which is technically undocumented!