### PR TITLE
add connectFauxDOM option to discard existing node

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -97,7 +97,7 @@ You also have access to **mixins** which makes it easy to render faux nodes, and
 
 The **core** mixin supplies the following methods:
 
-* **`connectFauxDOM(node,name)`**: This will store `node` in `this.connectedFauxDOM[name]`, and make an asynchronous call to `drawFauxDOM`. The node can be a faux element or a string, in which case a faux element is instantiated. The node is returned for convenience. A component can have multiple connected nodes.
+* **`connectFauxDOM(node, name)`**: This will store `node` in `this.connectedFauxDOM[name]`, and make an asynchronous call to `drawFauxDOM`. The node can be a faux element or a string, in which case a faux element is instantiated. The node is returned for convenience. A component can have multiple connected nodes. If the node already exists, it will be reused by default. If you need to force a new node, use the form `connectFauxDOM(node, name, discardNode)` setting the optional third argument `discardNode` to `true`.
 * **`drawFauxDOM()`**: This will update component state (causing a render) with virtual DOM (through `node.toReact()`) for all previously `connect`ed faux nodes. Each node's representation will be on `this.state[name]`, where `name` is the one used in the `connect` call.
 
 If you also add the **anim** mixin then you get:

--- a/lib/mixins/core.js
+++ b/lib/mixins/core.js
@@ -6,8 +6,8 @@ var mixin = {
     this.connectedFauxDOM = {}
     this.animateFauxDOMUntil = 0
   },
-  connectFauxDOM: function (node, name) {
-    if (!this.connectedFauxDOM[name]) {
+  connectFauxDOM: function (node, name, discardNode) {
+    if (!this.connectedFauxDOM[name] || discardNode) {
       this.connectedFauxDOM[name] = typeof node !== 'string' ? node : new Element(node)
       setTimeout(this.drawFauxDOM)
     }


### PR DESCRIPTION
Hi @Olical, this is a followup from #85. It adds the possibility to connect a node to the faux DOM while discarding the existing one if any. Basically, it gives users the option to get back the previous behaviour (to reset a component for example). I actually needed this temporarily while testing components and found that would be the best way to do it.

Not sure if this needs testing? Let me know.