### PR TITLE
Update examples for react deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can find the latest version of the UMD version at https://unpkg.com/react-fa
 
 ## Example
 
-Complex usage with [D3][], ES6 modules and animations.
+Complex usage with [D3][], ES6 modules and animations. Clone it from [here][minimal-example-source].
 
 ```javascript
 import React from 'react'
@@ -57,8 +57,11 @@ import * as d3 from 'd3'
 import {withFauxDOM} from 'react-faux-dom'
 
 class MyReactComponent extends React.Component {
-  state = {
-    chart: 'loading...'
+  constructor(props) {
+    super(props)
+    this.state = {
+      chart: 'loading...'
+    }
   }
 
   componentDidMount () {
@@ -81,7 +84,7 @@ class MyReactComponent extends React.Component {
       </div>
     )
   }
-})
+}
 
 export default withFauxDOM(MyReactComponent)
 ```
@@ -156,3 +159,4 @@ Do what you want. Learn as much as you can. Unlicense more software.
 [rd3-demo]: https://rd3.now.sh
 [rd3-source]: https://github.com/tibotiber/rd3
 [AdilBaaj-post]: https://blog.sicara.com/a-starting-point-on-using-d3-with-react-869fdf3dfaf
+[minimal-example-source]: https://github.com/tibotiber/rfd-min-example

--- a/examples/animate-d3-with-hoc/index.js
+++ b/examples/animate-d3-with-hoc/index.js
@@ -3,17 +3,21 @@ var ReactDOM = require('react-dom')
 var withFauxDOM = require('../../lib/ReactFauxDOM').withFauxDOM
 var d3 = require('d3')
 
-var Chart = React.createClass({
-  getInitialState: function () {
-    return { look: 'stacked' }
-  },
-  render: function () {
+class Chart extends React.Component {
+  constructor (props) {
+    super(props)
+    this.toggle = this.toggle.bind(this)
+    this.state = { look: 'stacked' }
+  }
+
+  render () {
     return <div>
       <button onClick={this.toggle}>Toggle</button>
       {this.state.chart}
     </div>
-  },
-  toggle: function () {
+  }
+
+  toggle () {
     if (this.state.look === 'stacked') {
       this.setState({ look: 'grouped' })
       this.transitionGrouped()
@@ -21,8 +25,9 @@ var Chart = React.createClass({
       this.setState({ look: 'stacked' })
       this.transitionStacked()
     }
-  },
-  componentDidMount: function () {
+  }
+
+  componentDidMount () {
     // This will create a faux div and store its virtual DOM
     // in state.chart
     var faux = this.connectFauxDOM('div', 'chart')
@@ -150,7 +155,7 @@ var Chart = React.createClass({
       return a.map(function (d, i) { return {x: i, y: Math.max(0, d)} })
     }
   }
-})
+}
 
 var FauxChart = withFauxDOM(Chart)
 

--- a/examples/update-d3-with-hoc/Chart.js
+++ b/examples/update-d3-with-hoc/Chart.js
@@ -1,33 +1,37 @@
 var React = require('react')
+var PropTypes = require('prop-types')
 var withFauxDOM = require('../../lib/ReactFauxDOM').withFauxDOM
 var d3 = require('d3')
 
-var Chart = React.createClass({
-  propsTypes: {
-    title: React.PropTypes.string.isRequired,
-    data: React.PropTypes.arrayOf(React.PropTypes.number).isRequired
-  },
-  getInitialState: function () {
-    return {
+class Chart extends React.Component {
+  constructor (props) {
+    super(props)
+    this.renderD3 = this.renderD3.bind(this)
+    this.updateD3 = this.updateD3.bind(this)
+    this.state = {
       chart: 'loading...'
     }
-  },
-  componentDidMount: function () {
+  }
+
+  componentDidMount () {
     this.renderD3()
-  },
-  componentDidUpdate: function (prevProps, prevState) {
+  }
+
+  componentDidUpdate (prevProps, prevState) {
     if (this.props !== prevProps) {
       this.updateD3()
     }
-  },
-  render: function () {
+  }
+
+  render () {
     return (
       <div>
         {this.state.chart}
       </div>
     )
-  },
-  renderD3: function () {
+  }
+
+  renderD3 () {
     var data = this.props.data
 
     // This will create a faux div and store its virtual DOM in state.chart
@@ -74,8 +78,9 @@ var Chart = React.createClass({
       })
       .attr('cy', yBuffer)
       .attr('r', function (d, i) { return d })
-  },
-  updateD3: function () {
+  }
+
+  updateD3 () {
     var data = this.props.data
 
     /* code below from Alan Smith except changes mentioned previously */
@@ -110,7 +115,12 @@ var Chart = React.createClass({
 
     d3.select('text').text(this.props.title)
   }
-})
+}
+
+Chart.propTypes = {
+  title: PropTypes.string.isRequired,
+  data: PropTypes.arrayOf(PropTypes.number).isRequired
+}
 
 const FauxChart = withFauxDOM(Chart)
 

--- a/examples/update-d3-with-hoc/package.json
+++ b/examples/update-d3-with-hoc/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "browserify": "^13.0.0",
     "d3": "^3.5.16",
+    "prop-types": "^15.5.10",
     "react": "^0.14.6",
     "react-dom": "^0.14.6",
     "reactify": "^1.1.1"


### PR DESCRIPTION
- Updated the examples taking recent deprecations into account, namely no more `React.createClass` and use `prop-types` package. 
- Also it does not assume that class properties are available from babel anymore. 
- Added a link to the minimal example repo I created in the README, next to the example code.