### PR TITLE
No longer using super and passing methods through props

### DIFF
--- a/lib/withFauxDOM.js
+++ b/lib/withFauxDOM.js
@@ -1,29 +1,16 @@
 var Element = require('./Element')
 var mapValues = require('./utils/mapValues')
 var createClass = require('create-react-class')
+var React = require('react')
 
-function withFauxDOM (WrappedComponent) {
-  // use inheritance inversion to access and extend WrappedComponent's
-  // state and lifecycle/class methods. More details on this technique at
-  // https://medium.com/@franleplant/react-higher-order-components-in-depth-cf9032ee6c3e
-
-  function applySuper (name, thisArg, args) {
-    var fn = WrappedComponent.prototype[name]
-
-    if (typeof fn === 'function') {
-      return fn.apply(thisArg, args)
-    }
-  }
-
-  var WithFauxDOM = createClass({
+function withFauxDOM (Child) {
+  var Parent = createClass({
     componentWillMount: function () {
-      applySuper('componentWillMount', this, arguments)
       this.connectedFauxDOM = {}
       this.animateFauxDOMUntil = 0
     },
 
     componentWillUnmount: function () {
-      applySuper('componentWillUnmount', this, arguments)
       this.stopAnimatingFauxDOM()
     },
 
@@ -65,17 +52,18 @@ function withFauxDOM (WrappedComponent) {
     },
 
     render: function () {
-      return applySuper('render', this, arguments)
+      var props = Object.assign({}, this.props, this)
+      return React.createElement(Child, props, this.children)
     }
   })
 
-  WithFauxDOM.displayName = ['WithFauxDOM(', getDisplayName(WrappedComponent), ')'].join('')
+  Parent.displayName = ['WithFauxDOM(', getDisplayName(Child), ')'].join('')
 
-  return WithFauxDOM
+  return Parent
 }
 
-function getDisplayName (WrappedComponent) {
-  return WrappedComponent.displayName || WrappedComponent.name || 'Component'
+function getDisplayName (component) {
+  return component.displayName || component.name || 'Component'
 }
 
 module.exports = withFauxDOM


### PR DESCRIPTION
A partial solution for #96. It doesn't work yet, but I think it's the right direction? I changed `App.js` in the example repository to this:

```js
class MyReactComponent extends React.Component {
  constructor (props) {
    super(props)
    this.state = {
      chart: 'loading...'
    }
  }

  componentDidMount () {
    const faux = this.props.connectFauxDOM('div', 'chart')
    d3.select(faux)
      .append('div')
      .html('Hello World!')
    this.props.animateFauxDOM(800)
  }

  render () {
    return (
      <div>
        <h2>Here is some fancy data:</h2>
        <div className='renderedD3'>
          {this.state.chart}
        </div>
      </div>
    )
  }
}
```

So it's not that different. We no longer need to call super since it's a wrapper too which is nice. The problem is the state management and how the API should be laid out if it's on props. I'm pretty tired and didn't want to do something I would later regret, so I thought I'd commit what I had so far.

Thoughts are appreciated, maybe it's not far off?