### PR TITLE
Expose drawFauxDOM in HOC

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -101,6 +101,7 @@ To use it, simply import it with `import {withFauxDOM} from 'react-faux-dom'` or
 The `withFauxDOM()` HOC passes the following methods to your component via props:
 
 * **`connectFauxDOM(node, name)`**: This will store the `node` element and make it available via `this.props[name]`. It also makes an asynchronous call to `drawFauxDOM`. The node can be a faux element or a string, in which case a faux element is instantiated. The node is returned for convenience. A component can have multiple connected nodes. If the node already exists, it will be reused by default. If you need to force a new node, use the form `connectFauxDOM(node, name, discardNode)` setting the optional third argument `discardNode` to `true`.
+* **`drawFauxDOM()`**: Render the fauxDOM to the virtual DOM with no animation.
 * **`animateFauxDOM(duration)`**: This will make a call to `drawFauxDOM` every 16 milliseconds until the duration has expired.
 * **`stopAnimatingFauxDOM()`**: Cancels eventual ongoing animation
 * **`isAnimatingFauxDOM()`**: Returns true or false depending on whether an animation is ongoing.

--- a/lib/withFauxDOM.js
+++ b/lib/withFauxDOM.js
@@ -47,6 +47,7 @@ function withFauxDOM (WrappedComponent) {
     render: function () {
       var props = Object.assign({}, this.props, this.state, {
         connectFauxDOM: this.connectFauxDOM,
+        drawFauxDOM: this.drawFauxDOM,
         animateFauxDOM: this.animateFauxDOM,
         stopAnimatingFauxDOM: this.stopAnimatingFauxDOM,
         isAnimatingFauxDOM: this.isAnimatingFauxDOM


### PR DESCRIPTION
Exposing `drawFauxDOM` via the HOC for non animated updates. Tested in my project and works as expected.

https://github.com/Olical/react-faux-dom/issues/120