### PR TITLE
prevent DrawFauxDOM from being called asynchronously if component is …

### DIFF
--- a/lib/_withFauxDOM.js
+++ b/lib/_withFauxDOM.js
@@ -11,11 +11,12 @@ function withFauxDOMFactory (Element) {
       },
       componentWillUnmount: function () {
         this.stopAnimatingFauxDOM()
+        this.stopDrawFauxDOM()
       },
       connectFauxDOM: function (node, name, discardNode) {
         if (!this.connectedFauxDOM[name] || discardNode) {
           this.connectedFauxDOM[name] = typeof node !== 'string' ? node : new Element(node)
-          setTimeout(this.drawFauxDOM)
+          this.drawFauxDOMTimeout = setTimeout(this.drawFauxDOM)
         }
         return this.connectedFauxDOM[name]
       },
@@ -40,6 +41,9 @@ function withFauxDOMFactory (Element) {
       stopAnimatingFauxDOM: function () {
         this.fauxDOMAnimationInterval = clearInterval(this.fauxDOMAnimationInterval)
         this.animateFauxDOMUntil = 0
+      },
+      stopDrawFauxDOM: function () {
+        this.drawFauxDOMTimeout = clearTimeout(this.drawFauxDOMTimeout)
       },
       isAnimatingFauxDOM: function () {
         return !!this.fauxDOMAnimationInterval

--- a/test/hoc.js
+++ b/test/hoc.js
@@ -100,6 +100,17 @@ test('stopAnimatingFauxDOM works as expected', function (t) {
   }, 500)
 })
 
+test('stopDrawFauxDOM works as expected', function (t) {
+  t.plan(1)
+  var comp = Comp()
+  comp.drawFauxDOM = sinon.spy()
+  comp.connectFauxDOM('div', 'a_div')
+  comp.componentWillUnmount()
+  setTimeout(function () {
+    t.ok(comp.drawFauxDOM.notCalled)
+  })
+})
+
 test('componentWillMount initialises correctly', function (t) {
   t.plan(2)
   var comp = Comp(true)
@@ -109,9 +120,11 @@ test('componentWillMount initialises correctly', function (t) {
 })
 
 test('componentWillUnmount cleans up correctly', function (t) {
-  t.plan(1)
+  t.plan(2)
   var comp = Comp()
   comp.stopAnimatingFauxDOM = sinon.spy()
+  comp.stopDrawFauxDOM = sinon.spy()
   comp.componentWillUnmount()
-  t.equal(comp.stopAnimatingFauxDOM.callCount, 1)
+  t.ok(comp.stopAnimatingFauxDOM.calledOnce)
+  t.ok(comp.stopDrawFauxDOM.calledOnce)
 })

--- a/test/hoc.js
+++ b/test/hoc.js
@@ -105,7 +105,7 @@ test('stopDrawFauxDOM works as expected', function (t) {
   var comp = Comp()
   comp.drawFauxDOM = sinon.spy()
   comp.connectFauxDOM('div', 'a_div')
-  comp.componentWillUnmount()
+  comp.stopDrawFauxDOM()
   setTimeout(function () {
     t.ok(comp.drawFauxDOM.notCalled)
   })


### PR DESCRIPTION
…quickly unmounted after mounting

While rare, it is possible that a component will become unmounted between scheduling the timeout and drawing the fauxDom. If setState is called on an unmounted component React will log a warning. This prevents that warning.