### PR TITLE
Updates to dependencies and React compatability

### DIFF
--- a/lib/_withFauxDOM.js
+++ b/lib/_withFauxDOM.js
@@ -6,7 +6,7 @@ var hoistNonReactStatics = require('hoist-non-react-statics')
 function withFauxDOMFactory (Element) {
   function withFauxDOM (WrappedComponent) {
     var WithFauxDOM = createReactClass({
-      componentWillMount: function () {
+      componentDidMount: function () {
         this.connectedFauxDOM = {}
         this.animateFauxDOMUntil = 0
       },

--- a/test/hoc.js
+++ b/test/hoc.js
@@ -111,10 +111,10 @@ test('stopDrawFauxDOM works as expected', function (t) {
   })
 })
 
-test('componentWillMount initialises correctly', function (t) {
+test('componentDidMount initialises correctly', function (t) {
   t.plan(2)
   var comp = Comp(true)
-  comp.componentWillMount()
+  comp.componentDidMount()
   t.deepEqual(comp.connectedFauxDOM, {})
   t.deepEqual(comp.animateFauxDOMUntil, 0)
 })

--- a/test/test-utils/component.js
+++ b/test/test-utils/component.js
@@ -19,7 +19,7 @@ function Component (noinit) {
   var comp = shallow(React.createElement(withFauxDOM(MockComponent)))
   var instance = comp.instance()
   instance.setState = sinon.spy()
-  noinit || instance.componentWillMount()
+  noinit || instance.componentDidMount()
   return instance
 }
 


### PR DESCRIPTION
Making this in response to #150. I moved `componentWillMount` to `componentDidMount`, and tried to update dependencies. Tests all pass, but the webpack step fails.

Sorry if I should have split this out, but I suspect it'll be quick for @Olical or @tibotiber to get this building with the updated dependencies. If you want to just revert to `771e3e8` it will fully build. Hope it's not too much trouble.